### PR TITLE
AveragingEpisodesController

### DIFF
--- a/bolero/controller/__init__.py
+++ b/bolero/controller/__init__.py
@@ -1,4 +1,5 @@
-from .controller import Controller, ContextualController
+from .controller import Controller, AveragingEpisodesController, \
+    ContextualController
 
 
-__all__ = ["Controller", "ContextualController"]
+__all__ = ["Controller", "AveragingEpisodesController", "ContextualController"]

--- a/bolero/controller/controller.py
+++ b/bolero/controller/controller.py
@@ -214,8 +214,15 @@ class Controller(Base):
             print("[Controller] Episode: #%d" % (self.episode_cnt + 1))
 
         behavior = self.behavior_search.get_next_behavior()
-        feedbacks = self.episode_with(behavior, meta_parameter_keys,
-                                      meta_parameters)
+
+        fb = []
+        # if True:  # self.repetitions
+        for i in range(10):
+            self.environment.env.seed(i)
+            fb.append(sum(self.episode_with(behavior, meta_parameter_keys,
+                                            meta_parameters)))
+        feedbacks = [np.median(np.array(fb))]
+
         self.behavior_search.set_evaluation_feedback(feedbacks)
 
         if self.verbose >= 2:


### PR DESCRIPTION
 added an **AveragingEpisodesController**

- allows to accumulate and average reward histories by function that is passed via feedback_averaging_function
  - in many cases, the default should be reasonable: sum up the reward history of an individual rollout, collect them in a list and use the median of these values as a final return
- allows to prepare an environment for each repetition (e.g. seeding) to make results repeatable
- does not support recording of trajectories and raw reward histories