### PR TITLE
Fix include path so that <bolero/mars_environment/MARSEnvironment.h> …

### DIFF
--- a/src/environment/mars_environment/mars_environment.pc.in
+++ b/src/environment/mars_environment/mars_environment.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/lib
-includedir=${prefix}/include/bolero/@PROJECT_NAME@
+includedir=${prefix}/include/
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
…include works

Testing with an autoproj separate prefix installation